### PR TITLE
Refactor: introduce Repository abstraction to decouple global state

### DIFF
--- a/src/HaENet/src/main/java/hae/Config.java
+++ b/src/HaENet/src/main/java/hae/Config.java
@@ -1,10 +1,5 @@
 package hae;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 public class Config {
     public static String suffix = "3g2|3gp|7z|aac|abw|aif|aifc|aiff|apk|arc|au|avi|azw|bat|bin|bmp|bz|bz2|cmd|cmx|cod|com|csh|css|csv|dll|doc|docx|ear|eot|epub|exe|flac|flv|gif|gz|ico|ics|ief|jar|jfif|jpe|jpeg|jpg|less|m3u|mid|midi|mjs|mkv|mov|mp2|mp3|mp4|mpa|mpe|mpeg|mpg|mpkg|mpp|mpv2|odp|ods|odt|oga|ogg|ogv|ogx|otf|pbm|pdf|pgm|png|pnm|ppm|ppt|pptx|ra|ram|rar|ras|rgb|rmi|rtf|scss|sh|snd|svg|swf|tar|tif|tiff|ttf|vsd|war|wav|weba|webm|webp|wmv|woff|woff2|xbm|xls|xlsx|xpm|xul|xwd|zip";
 
@@ -65,8 +60,4 @@ public class Config {
     };
 
     public static Boolean proVersionStatus = true;
-
-    public static Map<String, Object[][]> globalRules = new HashMap<>();
-
-    public static ConcurrentHashMap<String, Map<String, List<String>>> globalDataMap = new ConcurrentHashMap<>();
 }

--- a/src/HaENet/src/main/java/hae/HaE.java
+++ b/src/HaENet/src/main/java/hae/HaE.java
@@ -11,6 +11,11 @@ import hae.instances.editor.RequestEditor;
 import hae.instances.editor.ResponseEditor;
 import hae.instances.editor.WebSocketEditor;
 import hae.instances.websocket.WebSocketMessageHandler;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
+import hae.repository.impl.DataRepositoryImpl;
+import hae.repository.impl.RuleRepositoryImpl;
+import hae.service.HandlerRegistry;
 import hae.utils.ConfigLoader;
 import hae.utils.DataManager;
 
@@ -31,30 +36,46 @@ public class HaE implements BurpExtension {
         // 配置文件加载
         ConfigLoader configLoader = new ConfigLoader(api);
 
-        MessageTableModel messageTableModel = new MessageTableModel(api, configLoader);
+        // 创建 Repository
+        RuleRepository ruleRepository = new RuleRepositoryImpl(configLoader.getRules());
+        DataRepository dataRepository = new DataRepositoryImpl(api);
+
+        MessageTableModel messageTableModel = new MessageTableModel(api, configLoader, ruleRepository);
 
         // 设置BurpSuite专业版状态
         Config.proVersionStatus = getBurpSuiteProStatus(api);
 
+        // 创建 HandlerRegistry（替代 component/Config 中的 handler 管理）
+        HandlerRegistry handlerRegistry = new HandlerRegistry(api, configLoader, messageTableModel, dataRepository, ruleRepository);
+        handlerRegistry.registerAll(Config.proVersionStatus);
+
         // 注册Tab页（用于查询数据）
-        api.userInterface().registerSuiteTab("HaE", new Main(api, configLoader, messageTableModel));
+        api.userInterface().registerSuiteTab("HaE",
+                new Main(api, configLoader, messageTableModel, ruleRepository, dataRepository, handlerRegistry));
 
         // 注册WebSocket处理器
-        api.proxy().registerWebSocketCreationHandler(proxyWebSocketCreation -> proxyWebSocketCreation.proxyWebSocket().registerProxyMessageHandler(new WebSocketMessageHandler(api, configLoader)));
+        api.proxy().registerWebSocketCreationHandler(proxyWebSocketCreation ->
+                proxyWebSocketCreation.proxyWebSocket().registerProxyMessageHandler(
+                        new WebSocketMessageHandler(api, configLoader, dataRepository, ruleRepository)));
 
         // 注册消息编辑框（用于展示数据）
-        api.userInterface().registerHttpRequestEditorProvider(new RequestEditor(api, configLoader));
-        api.userInterface().registerHttpResponseEditorProvider(new ResponseEditor(api, configLoader));
-        api.userInterface().registerWebSocketMessageEditorProvider(new WebSocketEditor(api, configLoader));
+        api.userInterface().registerHttpRequestEditorProvider(
+                new RequestEditor(api, configLoader, dataRepository, ruleRepository));
+        api.userInterface().registerHttpResponseEditorProvider(
+                new ResponseEditor(api, configLoader, dataRepository, ruleRepository));
+        api.userInterface().registerWebSocketMessageEditorProvider(
+                new WebSocketEditor(api, configLoader, dataRepository, ruleRepository));
 
-        // 从BurpSuite里加载数据
+        // 从BurpSuite里加载数据（打破循环依赖）
+        dataRepository.loadFromPersistence();
         DataManager dataManager = new DataManager(api);
         dataManager.loadData(messageTableModel);
 
         api.extension().registerUnloadingHandler(() -> {
             // 卸载清空数据
-            Config.globalDataMap.clear();
+            dataRepository.clear();
             DataCache.clear();
+            handlerRegistry.unregisterAll();
         });
     }
 

--- a/src/HaENet/src/main/java/hae/component/Config.java
+++ b/src/HaENet/src/main/java/hae/component/Config.java
@@ -1,11 +1,9 @@
 package hae.component;
 
 import burp.api.montoya.MontoyaApi;
-import burp.api.montoya.core.Registration;
 import hae.component.board.message.MessageTableModel;
 import hae.component.rule.Rules;
-import hae.instances.http.HttpMessageActiveHandler;
-import hae.instances.http.HttpMessagePassiveHandler;
+import hae.service.HandlerRegistry;
 import hae.utils.ConfigLoader;
 import hae.utils.UIEnhancer;
 
@@ -28,20 +26,17 @@ public class Config extends JPanel {
     private final ConfigLoader configLoader;
     private final MessageTableModel messageTableModel;
     private final Rules rules;
-
-    private Registration activeHandler;
-    private Registration passiveHandler;
+    private final HandlerRegistry handlerRegistry;
 
     private boolean isLoadingData = false;
 
-    public Config(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel, Rules rules) {
+    public Config(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel, Rules rules,
+                  HandlerRegistry handlerRegistry) {
         this.api = api;
         this.configLoader = configLoader;
         this.messageTableModel = messageTableModel;
         this.rules = rules;
-
-        this.activeHandler = api.http().registerHttpHandler(new HttpMessageActiveHandler(api, configLoader, messageTableModel));
-        this.passiveHandler = api.scanner().registerScanCheck(new HttpMessagePassiveHandler(api, configLoader, messageTableModel));
+        this.handlerRegistry = handlerRegistry;
 
         initComponents();
     }
@@ -398,21 +393,9 @@ public class Config extends JPanel {
         configLoader.setMode(selected ? "true" : "false");
 
         if (checkBox.isSelected()) {
-            if (hae.Config.proVersionStatus && passiveHandler.isRegistered()) {
-                passiveHandler.deregister();
-            }
-
-            if (!activeHandler.isRegistered()) {
-                activeHandler = api.http().registerHttpHandler(new HttpMessageActiveHandler(api, configLoader, messageTableModel));
-            }
+            handlerRegistry.switchToActiveMode();
         } else {
-            if (hae.Config.proVersionStatus && !passiveHandler.isRegistered()) {
-                passiveHandler = api.scanner().registerScanCheck(new HttpMessagePassiveHandler(api, configLoader, messageTableModel));
-            }
-
-            if (activeHandler.isRegistered()) {
-                activeHandler.deregister();
-            }
+            handlerRegistry.switchToPassiveMode();
         }
     }
 

--- a/src/HaENet/src/main/java/hae/component/Main.java
+++ b/src/HaENet/src/main/java/hae/component/Main.java
@@ -4,6 +4,9 @@ import burp.api.montoya.MontoyaApi;
 import hae.component.board.Databoard;
 import hae.component.board.message.MessageTableModel;
 import hae.component.rule.Rules;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
+import hae.service.HandlerRegistry;
 import hae.utils.ConfigLoader;
 import hae.utils.UIEnhancer;
 
@@ -17,11 +20,18 @@ public class Main extends JPanel {
     private final MontoyaApi api;
     private final ConfigLoader configLoader;
     private final MessageTableModel messageTableModel;
+    private final RuleRepository ruleRepository;
+    private final DataRepository dataRepository;
+    private final HandlerRegistry handlerRegistry;
 
-    public Main(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel) {
+    public Main(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel,
+                RuleRepository ruleRepository, DataRepository dataRepository, HandlerRegistry handlerRegistry) {
         this.api = api;
         this.configLoader = configLoader;
         this.messageTableModel = messageTableModel;
+        this.ruleRepository = ruleRepository;
+        this.dataRepository = dataRepository;
+        this.handlerRegistry = handlerRegistry;
 
         initComponents();
     }
@@ -55,10 +65,10 @@ public class Main extends JPanel {
                 new Insets(0, 0, 0, 0), 0, 0));
 
         // 依次添加Rules、Config、Databoard
-        Rules rules = new Rules(api, configLoader);
+        Rules rules = new Rules(api, configLoader, ruleRepository);
         mainTabbedPane.addTab("Rules", rules);
-        mainTabbedPane.addTab("Databoard", new Databoard(api, configLoader, messageTableModel));
-        mainTabbedPane.addTab("Config", new Config(api, configLoader, messageTableModel, rules));
+        mainTabbedPane.addTab("Databoard", new Databoard(api, configLoader, messageTableModel, dataRepository));
+        mainTabbedPane.addTab("Config", new Config(api, configLoader, messageTableModel, rules, handlerRegistry));
     }
 
     private ImageIcon getImageIcon(boolean isDark) {

--- a/src/HaENet/src/main/java/hae/component/board/message/MessageTableModel.java
+++ b/src/HaENet/src/main/java/hae/component/board/message/MessageTableModel.java
@@ -10,6 +10,7 @@ import burp.api.montoya.ui.UserInterface;
 import burp.api.montoya.ui.editor.HttpRequestEditor;
 import burp.api.montoya.ui.editor.HttpResponseEditor;
 import hae.Config;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.DataManager;
 import hae.utils.string.StringProcessor;
@@ -32,16 +33,18 @@ import static burp.api.montoya.ui.editor.EditorOptions.READ_ONLY;
 public class MessageTableModel extends AbstractTableModel {
     private final MontoyaApi api;
     private final ConfigLoader configLoader;
+    private final RuleRepository ruleRepository;
     private final MessageTable messageTable;
     private final JSplitPane splitPane;
     private final LinkedList<MessageEntry> log = new LinkedList<>();
     private final LinkedList<MessageEntry> filteredLog;
     private SwingWorker<Void, Void> currentWorker;
 
-    public MessageTableModel(MontoyaApi api, ConfigLoader configLoader) {
+    public MessageTableModel(MontoyaApi api, ConfigLoader configLoader, RuleRepository ruleRepository) {
         this.filteredLog = new LinkedList<>();
         this.api = api;
         this.configLoader = configLoader;
+        this.ruleRepository = ruleRepository;
 
         UserInterface userInterface = api.userInterface();
         HttpRequestEditor requestViewer = userInterface.createHttpRequestEditor(READ_ONLY);
@@ -327,8 +330,8 @@ public class MessageTableModel extends AbstractTableModel {
                         .map(HttpHeader::toString)
                         .collect(Collectors.joining("\r\n"));
 
-                Config.globalRules.keySet().forEach(i -> {
-                    for (Object[] objects : Config.globalRules.get(i)) {
+                ruleRepository.getAllGroupNames().forEach(i -> {
+                    for (Object[] objects : ruleRepository.getRulesByGroup(i)) {
                         String name = objects[1].toString();
                         String format = objects[4].toString();
                         String scope = objects[6].toString();

--- a/src/HaENet/src/main/java/hae/component/rule/Rule.java
+++ b/src/HaENet/src/main/java/hae/component/rule/Rule.java
@@ -2,6 +2,7 @@ package hae.component.rule;
 
 import burp.api.montoya.MontoyaApi;
 import hae.Config;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.rule.RuleProcessor;
 
@@ -25,10 +26,10 @@ public class Rule extends JPanel {
     private final JTabbedPane tabbedPane;
     private JCheckBox headerCheckBox;
 
-    public Rule(MontoyaApi api, ConfigLoader configLoader, Object[][] data, JTabbedPane tabbedPane) {
+    public Rule(MontoyaApi api, ConfigLoader configLoader, Object[][] data, JTabbedPane tabbedPane, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
-        this.ruleProcessor = new RuleProcessor(api, configLoader);
+        this.ruleProcessor = new RuleProcessor(api, configLoader, ruleRepository);
         this.tabbedPane = tabbedPane;
 
         initComponents(data);

--- a/src/HaENet/src/main/java/hae/component/rule/Rules.java
+++ b/src/HaENet/src/main/java/hae/component/rule/Rules.java
@@ -2,6 +2,7 @@ package hae.component.rule;
 
 import burp.api.montoya.MontoyaApi;
 import hae.Config;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.rule.RuleProcessor;
 
@@ -11,6 +12,7 @@ import java.awt.event.*;
 
 public class Rules extends JTabbedPane {
     private final MontoyaApi api;
+    private final RuleRepository ruleRepository;
     private final RuleProcessor ruleProcessor;
     private final JTextField ruleGroupNameTextField;
     private ConfigLoader configLoader;
@@ -47,10 +49,11 @@ public class Rules extends JTabbedPane {
         }
     };
 
-    public Rules(MontoyaApi api, ConfigLoader configLoader) {
+    public Rules(MontoyaApi api, ConfigLoader configLoader, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
-        this.ruleProcessor = new RuleProcessor(api, configLoader);
+        this.ruleRepository = ruleRepository;
+        this.ruleProcessor = new RuleProcessor(api, configLoader, ruleRepository);
         this.ruleGroupNameTextField = new JTextField();
 
         initComponents();
@@ -103,7 +106,7 @@ public class Rules extends JTabbedPane {
                                 e.consume();
                                 // 直接创建新标签
                                 String newTitle = ruleProcessor.newRule();
-                                Rule newRule = new Rule(api, configLoader, Config.ruleTemplate, Rules.this);
+                                Rule newRule = new Rule(api, configLoader, Config.ruleTemplate, Rules.this, ruleRepository);
                                 insertTab(newTitle, null, newRule, null, getTabCount() - 1);
                                 setSelectedIndex(getTabCount() - 2);
                             } else {
@@ -135,7 +138,8 @@ public class Rules extends JTabbedPane {
         removeAll();
 
         this.configLoader = new ConfigLoader(api);
-        Config.globalRules.keySet().forEach(i -> addTab(i, new Rule(api, configLoader, hae.Config.globalRules.get(i), this)));
+        ruleRepository.setAll(configLoader.getRules());
+        ruleRepository.getAllGroupNames().forEach(i -> addTab(i, new Rule(api, configLoader, ruleRepository.getRulesByGroup(i), this, ruleRepository)));
         addTab("...", null);
     }
 

--- a/src/HaENet/src/main/java/hae/instances/editor/RequestEditor.java
+++ b/src/HaENet/src/main/java/hae/instances/editor/RequestEditor.java
@@ -12,6 +12,8 @@ import burp.api.montoya.ui.editor.extension.HttpRequestEditorProvider;
 import hae.Config;
 import hae.component.board.table.Datatable;
 import hae.instances.http.utils.MessageProcessor;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.http.HttpUtils;
 import hae.utils.string.StringProcessor;
@@ -25,10 +27,15 @@ import java.util.Map;
 public class RequestEditor implements HttpRequestEditorProvider {
     private final MontoyaApi api;
     private final ConfigLoader configLoader;
+    private final DataRepository dataRepository;
+    private final RuleRepository ruleRepository;
 
-    public RequestEditor(MontoyaApi api, ConfigLoader configLoader) {
+    public RequestEditor(MontoyaApi api, ConfigLoader configLoader,
+                         DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
+        this.dataRepository = dataRepository;
+        this.ruleRepository = ruleRepository;
     }
 
     public static boolean isListHasData(List<Map<String, String>> dataList) {
@@ -55,7 +62,7 @@ public class RequestEditor implements HttpRequestEditorProvider {
 
     @Override
     public ExtensionProvidedHttpRequestEditor provideHttpRequestEditor(EditorCreationContext editorCreationContext) {
-        return new Editor(api, configLoader, editorCreationContext);
+        return new Editor(api, configLoader, dataRepository, ruleRepository, editorCreationContext);
     }
 
     private static class Editor implements ExtensionProvidedHttpRequestEditor {
@@ -68,12 +75,14 @@ public class RequestEditor implements HttpRequestEditorProvider {
         private HttpRequestResponse requestResponse;
         private List<Map<String, String>> dataList;
 
-        public Editor(MontoyaApi api, ConfigLoader configLoader, EditorCreationContext creationContext) {
+        public Editor(MontoyaApi api, ConfigLoader configLoader,
+                      DataRepository dataRepository, RuleRepository ruleRepository,
+                      EditorCreationContext creationContext) {
             this.api = api;
             this.configLoader = configLoader;
             this.httpUtils = new HttpUtils(api, configLoader);
             this.creationContext = creationContext;
-            this.messageProcessor = new MessageProcessor(api, configLoader);
+            this.messageProcessor = new MessageProcessor(api, configLoader, dataRepository, ruleRepository);
         }
 
         @Override

--- a/src/HaENet/src/main/java/hae/instances/editor/ResponseEditor.java
+++ b/src/HaENet/src/main/java/hae/instances/editor/ResponseEditor.java
@@ -12,6 +12,8 @@ import burp.api.montoya.ui.editor.extension.ExtensionProvidedHttpResponseEditor;
 import burp.api.montoya.ui.editor.extension.HttpResponseEditorProvider;
 import hae.component.board.table.Datatable;
 import hae.instances.http.utils.MessageProcessor;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.http.HttpUtils;
 import hae.utils.string.StringProcessor;
@@ -24,15 +26,20 @@ import java.util.Map;
 public class ResponseEditor implements HttpResponseEditorProvider {
     private final MontoyaApi api;
     private final ConfigLoader configLoader;
+    private final DataRepository dataRepository;
+    private final RuleRepository ruleRepository;
 
-    public ResponseEditor(MontoyaApi api, ConfigLoader configLoader) {
+    public ResponseEditor(MontoyaApi api, ConfigLoader configLoader,
+                          DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
+        this.dataRepository = dataRepository;
+        this.ruleRepository = ruleRepository;
     }
 
     @Override
     public ExtensionProvidedHttpResponseEditor provideHttpResponseEditor(EditorCreationContext editorCreationContext) {
-        return new Editor(api, configLoader, editorCreationContext);
+        return new Editor(api, configLoader, dataRepository, ruleRepository, editorCreationContext);
     }
 
     private static class Editor implements ExtensionProvidedHttpResponseEditor {
@@ -45,12 +52,14 @@ public class ResponseEditor implements HttpResponseEditorProvider {
         private HttpRequestResponse requestResponse;
         private List<Map<String, String>> dataList;
 
-        public Editor(MontoyaApi api, ConfigLoader configLoader, EditorCreationContext creationContext) {
+        public Editor(MontoyaApi api, ConfigLoader configLoader,
+                      DataRepository dataRepository, RuleRepository ruleRepository,
+                      EditorCreationContext creationContext) {
             this.api = api;
             this.configLoader = configLoader;
             this.httpUtils = new HttpUtils(api, configLoader);
             this.creationContext = creationContext;
-            this.messageProcessor = new MessageProcessor(api, configLoader);
+            this.messageProcessor = new MessageProcessor(api, configLoader, dataRepository, ruleRepository);
         }
 
         @Override

--- a/src/HaENet/src/main/java/hae/instances/editor/WebSocketEditor.java
+++ b/src/HaENet/src/main/java/hae/instances/editor/WebSocketEditor.java
@@ -10,6 +10,8 @@ import burp.api.montoya.ui.editor.extension.ExtensionProvidedWebSocketMessageEdi
 import burp.api.montoya.ui.editor.extension.WebSocketMessageEditorProvider;
 import hae.component.board.table.Datatable;
 import hae.instances.http.utils.MessageProcessor;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 
 import javax.swing.*;
@@ -20,15 +22,20 @@ import java.util.Map;
 public class WebSocketEditor implements WebSocketMessageEditorProvider {
     private final MontoyaApi api;
     private final ConfigLoader configLoader;
+    private final DataRepository dataRepository;
+    private final RuleRepository ruleRepository;
 
-    public WebSocketEditor(MontoyaApi api, ConfigLoader configLoader) {
+    public WebSocketEditor(MontoyaApi api, ConfigLoader configLoader,
+                           DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
+        this.dataRepository = dataRepository;
+        this.ruleRepository = ruleRepository;
     }
 
     @Override
     public ExtensionProvidedWebSocketMessageEditor provideMessageEditor(EditorCreationContext editorCreationContext) {
-        return new Editor(api, configLoader, editorCreationContext);
+        return new Editor(api, configLoader, dataRepository, ruleRepository, editorCreationContext);
     }
 
     private static class Editor implements ExtensionProvidedWebSocketMessageEditor {
@@ -40,11 +47,13 @@ public class WebSocketEditor implements WebSocketMessageEditorProvider {
         private ByteArray message;
         private List<Map<String, String>> dataList;
 
-        public Editor(MontoyaApi api, ConfigLoader configLoader, EditorCreationContext creationContext) {
+        public Editor(MontoyaApi api, ConfigLoader configLoader,
+                      DataRepository dataRepository, RuleRepository ruleRepository,
+                      EditorCreationContext creationContext) {
             this.api = api;
             this.configLoader = configLoader;
             this.creationContext = creationContext;
-            this.messageProcessor = new MessageProcessor(api, configLoader);
+            this.messageProcessor = new MessageProcessor(api, configLoader, dataRepository, ruleRepository);
         }
 
         @Override

--- a/src/HaENet/src/main/java/hae/instances/http/HttpMessageActiveHandler.java
+++ b/src/HaENet/src/main/java/hae/instances/http/HttpMessageActiveHandler.java
@@ -8,6 +8,8 @@ import burp.api.montoya.http.message.HttpRequestResponse;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import hae.component.board.message.MessageTableModel;
 import hae.instances.http.utils.MessageProcessor;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.http.HttpUtils;
 import hae.utils.string.StringProcessor;
@@ -30,12 +32,13 @@ public class HttpMessageActiveHandler implements HttpHandler {
     private final ThreadLocal<List<String>> colorList = ThreadLocal.withInitial(ArrayList::new);
     private final ThreadLocal<List<String>> commentList = ThreadLocal.withInitial(ArrayList::new);
 
-    public HttpMessageActiveHandler(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel) {
+    public HttpMessageActiveHandler(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel,
+                                    DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
         this.httpUtils = new HttpUtils(api, configLoader);
         this.messageTableModel = messageTableModel;
-        this.messageProcessor = new MessageProcessor(api, configLoader);
+        this.messageProcessor = new MessageProcessor(api, configLoader, dataRepository, ruleRepository);
     }
 
     @Override

--- a/src/HaENet/src/main/java/hae/instances/http/HttpMessagePassiveHandler.java
+++ b/src/HaENet/src/main/java/hae/instances/http/HttpMessagePassiveHandler.java
@@ -11,6 +11,8 @@ import burp.api.montoya.scanner.audit.insertionpoint.AuditInsertionPoint;
 import burp.api.montoya.scanner.audit.issues.AuditIssue;
 import hae.component.board.message.MessageTableModel;
 import hae.instances.http.utils.MessageProcessor;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 import hae.utils.http.HttpUtils;
 import hae.utils.string.StringProcessor;
@@ -32,12 +34,13 @@ public class HttpMessagePassiveHandler implements ScanCheck {
     private final MessageTableModel messageTableModel;
     private final MessageProcessor messageProcessor;
 
-    public HttpMessagePassiveHandler(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel) {
+    public HttpMessagePassiveHandler(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel,
+                                     DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
         this.configLoader = configLoader;
         this.httpUtils = new HttpUtils(api, configLoader);
         this.messageTableModel = messageTableModel;
-        this.messageProcessor = new MessageProcessor(api, configLoader);
+        this.messageProcessor = new MessageProcessor(api, configLoader, dataRepository, ruleRepository);
     }
 
     @Override

--- a/src/HaENet/src/main/java/hae/instances/http/utils/MessageProcessor.java
+++ b/src/HaENet/src/main/java/hae/instances/http/utils/MessageProcessor.java
@@ -5,6 +5,8 @@ import burp.api.montoya.http.message.HttpHeader;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
 import hae.Config;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 
 import java.nio.charset.StandardCharsets;
@@ -15,9 +17,9 @@ public class MessageProcessor {
     private final MontoyaApi api;
     private final RegularMatcher regularMatcher;
 
-    public MessageProcessor(MontoyaApi api, ConfigLoader configLoader) {
+    public MessageProcessor(MontoyaApi api, ConfigLoader configLoader, DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
-        this.regularMatcher = new RegularMatcher(api, configLoader);
+        this.regularMatcher = new RegularMatcher(api, configLoader, dataRepository, ruleRepository);
     }
 
     public List<Map<String, String>> processMessage(String host, String message, boolean flag) {

--- a/src/HaENet/src/main/java/hae/instances/websocket/WebSocketMessageHandler.java
+++ b/src/HaENet/src/main/java/hae/instances/websocket/WebSocketMessageHandler.java
@@ -4,6 +4,8 @@ import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.HighlightColor;
 import burp.api.montoya.proxy.websocket.*;
 import hae.instances.http.utils.MessageProcessor;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
 import hae.utils.ConfigLoader;
 
 import java.util.List;
@@ -13,9 +15,10 @@ public class WebSocketMessageHandler implements ProxyMessageHandler {
     private final MontoyaApi api;
     private final MessageProcessor messageProcessor;
 
-    public WebSocketMessageHandler(MontoyaApi api, ConfigLoader configLoader) {
+    public WebSocketMessageHandler(MontoyaApi api, ConfigLoader configLoader,
+                                   DataRepository dataRepository, RuleRepository ruleRepository) {
         this.api = api;
-        this.messageProcessor = new MessageProcessor(api, configLoader);
+        this.messageProcessor = new MessageProcessor(api, configLoader, dataRepository, ruleRepository);
     }
 
     @Override

--- a/src/HaENet/src/main/java/hae/repository/DataRepository.java
+++ b/src/HaENet/src/main/java/hae/repository/DataRepository.java
@@ -1,0 +1,25 @@
+package hae.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface DataRepository {
+    // 读
+    Map<String, List<String>> getByHost(String host);
+    Set<String> getAllHosts();
+    boolean containsHost(String host);
+    boolean isEmpty();
+    int size();
+    Map<String, Map<String, List<String>>> getAll();
+
+    // 写
+    void mergeData(String host, String ruleName, List<String> data, boolean persist);
+    void putEmptyHost(String host);
+    void remove(String host);
+    void removeMatching(String hostPattern);
+    void clear();
+
+    // 持久化加载
+    void loadFromPersistence();
+}

--- a/src/HaENet/src/main/java/hae/repository/RuleRepository.java
+++ b/src/HaENet/src/main/java/hae/repository/RuleRepository.java
@@ -1,0 +1,21 @@
+package hae.repository;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface RuleRepository {
+    // 读
+    Object[][] getRulesByGroup(String groupName);
+    Set<String> getAllGroupNames();
+    boolean containsGroup(String groupName);
+    Map<String, Object[][]> getAll();
+
+    // 写
+    void setAll(Map<String, Object[][]> rules);
+    void putGroup(String groupName, Object[][] rules);
+    void removeGroup(String groupName);
+    void renameGroup(String oldName, String newName);
+    void updateRule(String groupName, int index, Object[] rule);
+    void addRule(String groupName, Object[] rule);
+    void removeRule(String groupName, int index);
+}

--- a/src/HaENet/src/main/java/hae/repository/impl/DataRepositoryImpl.java
+++ b/src/HaENet/src/main/java/hae/repository/impl/DataRepositoryImpl.java
@@ -1,0 +1,186 @@
+package hae.repository.impl;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.persistence.PersistedList;
+import burp.api.montoya.persistence.PersistedObject;
+import burp.api.montoya.persistence.Persistence;
+import hae.repository.DataRepository;
+import hae.utils.string.StringProcessor;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class DataRepositoryImpl implements DataRepository {
+    private final ConcurrentHashMap<String, Map<String, List<String>>> dataMap = new ConcurrentHashMap<>();
+    private final MontoyaApi api;
+    private final Persistence persistence;
+
+    public DataRepositoryImpl(MontoyaApi api) {
+        this.api = api;
+        this.persistence = api.persistence();
+    }
+
+    @Override
+    public Map<String, List<String>> getByHost(String host) {
+        return dataMap.get(host);
+    }
+
+    @Override
+    public Set<String> getAllHosts() {
+        return dataMap.keySet();
+    }
+
+    @Override
+    public boolean containsHost(String host) {
+        return dataMap.containsKey(host);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return dataMap.isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return dataMap.size();
+    }
+
+    @Override
+    public Map<String, Map<String, List<String>>> getAll() {
+        return dataMap;
+    }
+
+    @Override
+    public synchronized void mergeData(String host, String ruleName, List<String> data, boolean persist) {
+        if (Objects.equals(host, "") || host == null) {
+            return;
+        }
+
+        dataMap.compute(host, (existingHost, existingMap) -> {
+            Map<String, List<String>> gRuleMap = Optional.ofNullable(existingMap).orElse(new ConcurrentHashMap<>());
+
+            gRuleMap.merge(ruleName, new ArrayList<>(data), (existingList, newList) -> {
+                Set<String> combinedSet = new LinkedHashSet<>(existingList);
+                combinedSet.addAll(newList);
+                return new ArrayList<>(combinedSet);
+            });
+
+            if (persist) {
+                try {
+                    PersistedObject persistedObject = PersistedObject.persistedObject();
+                    gRuleMap.forEach((kName, vList) -> {
+                        PersistedList<String> persistedList = PersistedList.persistedStringList();
+                        persistedList.addAll(vList);
+                        persistedObject.setStringList(kName, persistedList);
+                    });
+                    putData("data", host, persistedObject);
+                } catch (Exception ignored) {
+                }
+            }
+
+            return gRuleMap;
+        });
+
+        String[] splitHost = host.split("\\.");
+        String onlyHost = host.split(":")[0];
+
+        String anyHost = (splitHost.length > 2 && !StringProcessor.matchHostIsIp(onlyHost))
+                ? StringProcessor.replaceFirstOccurrence(onlyHost, splitHost[0], "*") : "";
+
+        if (!dataMap.containsKey(anyHost) && !anyHost.isEmpty()) {
+            dataMap.put(anyHost, new HashMap<>());
+        }
+
+        if (!dataMap.containsKey("*")) {
+            dataMap.put("*", new HashMap<>());
+        }
+    }
+
+    @Override
+    public void putEmptyHost(String host) {
+        dataMap.put(host, new HashMap<>());
+    }
+
+    @Override
+    public void remove(String host) {
+        dataMap.remove(host);
+    }
+
+    @Override
+    public void removeMatching(String hostPattern) {
+        dataMap.keySet().parallelStream().forEach(key -> {
+            if (StringProcessor.matchesHostPattern(key, hostPattern) || hostPattern.equals("*")) {
+                dataMap.remove(key);
+            }
+        });
+
+        // 删除无用的通配符数据
+        Set<String> wildcardKeys = dataMap.keySet().stream()
+                .filter(key -> key.startsWith("*."))
+                .collect(Collectors.toSet());
+
+        Set<String> existingSuffixes = dataMap.keySet().stream()
+                .filter(key -> !key.startsWith("*."))
+                .map(key -> {
+                    int dotIndex = key.indexOf(".");
+                    return dotIndex != -1 ? key.substring(dotIndex) : "";
+                })
+                .collect(Collectors.toSet());
+
+        Set<String> keysToRemove = wildcardKeys.stream()
+                .filter(key -> !existingSuffixes.contains(key.substring(1)))
+                .collect(Collectors.toSet());
+
+        keysToRemove.forEach(dataMap::remove);
+
+        if (dataMap.size() == 1 && dataMap.keySet().stream().anyMatch(key -> key.equals("*"))) {
+            dataMap.remove("*");
+        }
+    }
+
+    @Override
+    public void clear() {
+        dataMap.clear();
+    }
+
+    @Override
+    public void loadFromPersistence() {
+        PersistedList<String> dataIndex = persistence.extensionData().getStringList("data");
+        if (dataIndex != null && !dataIndex.isEmpty()) {
+            dataIndex.forEach(index -> {
+                PersistedObject dataObj = persistence.extensionData().getChildObject(index);
+                try {
+                    dataObj.stringListKeys().forEach(dataKey ->
+                            mergeData(index, dataKey, dataObj.getStringList(dataKey).stream().toList(), false));
+                } catch (Exception ignored) {
+                }
+            });
+        }
+    }
+
+    private synchronized void putData(String dataType, String dataName, PersistedObject persistedObject) {
+        if (persistence.extensionData().getChildObject(dataName) != null) {
+            persistence.extensionData().deleteChildObject(dataName);
+        }
+        persistence.extensionData().setChildObject(dataName, persistedObject);
+
+        saveIndex(dataType, dataName);
+    }
+
+    private void saveIndex(String indexName, String indexValue) {
+        PersistedList<String> indexList = persistence.extensionData().getStringList(indexName);
+
+        if (indexList != null && !indexList.isEmpty()) {
+            persistence.extensionData().deleteStringList(indexName);
+        } else if (indexList == null) {
+            indexList = PersistedList.persistedStringList();
+        }
+
+        if (!indexList.contains(indexValue)) {
+            indexList.add(indexValue);
+        }
+
+        persistence.extensionData().setStringList(indexName, indexList);
+    }
+}

--- a/src/HaENet/src/main/java/hae/repository/impl/RuleRepositoryImpl.java
+++ b/src/HaENet/src/main/java/hae/repository/impl/RuleRepositoryImpl.java
@@ -1,0 +1,73 @@
+package hae.repository.impl;
+
+import hae.repository.RuleRepository;
+
+import java.util.*;
+
+public class RuleRepositoryImpl implements RuleRepository {
+    private final Map<String, Object[][]> rules;
+
+    public RuleRepositoryImpl(Map<String, Object[][]> initialRules) {
+        this.rules = new HashMap<>(initialRules);
+    }
+
+    @Override
+    public synchronized Object[][] getRulesByGroup(String groupName) {
+        return rules.get(groupName);
+    }
+
+    @Override
+    public synchronized Set<String> getAllGroupNames() {
+        return new HashSet<>(rules.keySet());
+    }
+
+    @Override
+    public synchronized boolean containsGroup(String groupName) {
+        return rules.containsKey(groupName);
+    }
+
+    @Override
+    public synchronized Map<String, Object[][]> getAll() {
+        return new HashMap<>(rules);
+    }
+
+    @Override
+    public synchronized void setAll(Map<String, Object[][]> newRules) {
+        rules.clear();
+        rules.putAll(newRules);
+    }
+
+    @Override
+    public synchronized void putGroup(String groupName, Object[][] groupRules) {
+        rules.put(groupName, groupRules);
+    }
+
+    @Override
+    public synchronized void removeGroup(String groupName) {
+        rules.remove(groupName);
+    }
+
+    @Override
+    public synchronized void renameGroup(String oldName, String newName) {
+        rules.put(newName, rules.remove(oldName));
+    }
+
+    @Override
+    public synchronized void updateRule(String groupName, int index, Object[] rule) {
+        rules.get(groupName)[index] = rule;
+    }
+
+    @Override
+    public synchronized void addRule(String groupName, Object[] rule) {
+        ArrayList<Object[]> x = new ArrayList<>(Arrays.asList(rules.get(groupName)));
+        x.add(rule);
+        rules.put(groupName, x.toArray(new Object[x.size()][]));
+    }
+
+    @Override
+    public synchronized void removeRule(String groupName, int index) {
+        ArrayList<Object[]> x = new ArrayList<>(Arrays.asList(rules.get(groupName)));
+        x.remove(index);
+        rules.put(groupName, x.toArray(new Object[x.size()][]));
+    }
+}

--- a/src/HaENet/src/main/java/hae/service/HandlerRegistry.java
+++ b/src/HaENet/src/main/java/hae/service/HandlerRegistry.java
@@ -1,0 +1,67 @@
+package hae.service;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.core.Registration;
+import hae.component.board.message.MessageTableModel;
+import hae.instances.http.HttpMessageActiveHandler;
+import hae.instances.http.HttpMessagePassiveHandler;
+import hae.repository.DataRepository;
+import hae.repository.RuleRepository;
+import hae.utils.ConfigLoader;
+
+public class HandlerRegistry {
+    private final MontoyaApi api;
+    private final ConfigLoader configLoader;
+    private final MessageTableModel messageTableModel;
+    private final DataRepository dataRepository;
+    private final RuleRepository ruleRepository;
+    private Registration activeHandler;
+    private Registration passiveHandler;
+
+    public HandlerRegistry(MontoyaApi api, ConfigLoader configLoader, MessageTableModel messageTableModel,
+                           DataRepository dataRepository, RuleRepository ruleRepository) {
+        this.api = api;
+        this.configLoader = configLoader;
+        this.messageTableModel = messageTableModel;
+        this.dataRepository = dataRepository;
+        this.ruleRepository = ruleRepository;
+    }
+
+    public void registerAll(boolean proVersion) {
+        this.activeHandler = api.http().registerHttpHandler(
+                new HttpMessageActiveHandler(api, configLoader, messageTableModel, dataRepository, ruleRepository));
+        this.passiveHandler = api.scanner().registerScanCheck(
+                new HttpMessagePassiveHandler(api, configLoader, messageTableModel, dataRepository, ruleRepository));
+    }
+
+    public void switchToActiveMode() {
+        if (hae.Config.proVersionStatus && passiveHandler.isRegistered()) {
+            passiveHandler.deregister();
+        }
+
+        if (!activeHandler.isRegistered()) {
+            activeHandler = api.http().registerHttpHandler(
+                    new HttpMessageActiveHandler(api, configLoader, messageTableModel, dataRepository, ruleRepository));
+        }
+    }
+
+    public void switchToPassiveMode() {
+        if (hae.Config.proVersionStatus && !passiveHandler.isRegistered()) {
+            passiveHandler = api.scanner().registerScanCheck(
+                    new HttpMessagePassiveHandler(api, configLoader, messageTableModel, dataRepository, ruleRepository));
+        }
+
+        if (activeHandler.isRegistered()) {
+            activeHandler.deregister();
+        }
+    }
+
+    public void unregisterAll() {
+        if (activeHandler != null && activeHandler.isRegistered()) {
+            activeHandler.deregister();
+        }
+        if (passiveHandler != null && passiveHandler.isRegistered()) {
+            passiveHandler.deregister();
+        }
+    }
+}

--- a/src/HaENet/src/main/java/hae/utils/ConfigLoader.java
+++ b/src/HaENet/src/main/java/hae/utils/ConfigLoader.java
@@ -45,7 +45,6 @@ public class ConfigLoader {
             initRules();
         }
 
-        Config.globalRules = getRules();
     }
 
     private static boolean isValidConfigPath(String configPath) {

--- a/src/HaENet/src/main/java/hae/utils/DataManager.java
+++ b/src/HaENet/src/main/java/hae/utils/DataManager.java
@@ -8,7 +8,6 @@ import burp.api.montoya.persistence.PersistedList;
 import burp.api.montoya.persistence.PersistedObject;
 import burp.api.montoya.persistence.Persistence;
 import hae.component.board.message.MessageTableModel;
-import hae.instances.http.utils.RegularMatcher;
 
 import java.util.List;
 import java.util.Objects;
@@ -34,12 +33,10 @@ public class DataManager {
     }
 
     public synchronized void loadData(MessageTableModel messageTableModel) {
-        // 1. 获取索引
-        PersistedList<String> dataIndex = persistence.extensionData().getStringList("data"); // 数据索引
-        PersistedList<String> messageIndex = persistence.extensionData().getStringList("message"); // 消息索引
+        // 获取消息索引
+        PersistedList<String> messageIndex = persistence.extensionData().getStringList("message");
 
-        // 2. 从索引获取数据
-        loadHaEData(dataIndex);
+        // 从索引加载消息数据
         loadMessageData(messageIndex, messageTableModel);
     }
 
@@ -57,18 +54,6 @@ public class DataManager {
         }
 
         persistence.extensionData().setStringList(indexName, indexList);
-    }
-
-    private void loadHaEData(PersistedList<String> dataIndex) {
-        if (dataIndex != null && !dataIndex.isEmpty()) {
-            dataIndex.forEach(index -> {
-                PersistedObject dataObj = persistence.extensionData().getChildObject(index);
-                try {
-                    dataObj.stringListKeys().forEach(dataKey -> RegularMatcher.updateGlobalMatchCache(api, index, dataKey, dataObj.getStringList(dataKey).stream().toList(), false));
-                } catch (Exception ignored) {
-                }
-            });
-        }
     }
 
     private void loadMessageData(PersistedList<String> messageIndex, MessageTableModel messageTableModel) {


### PR DESCRIPTION
## Summary

- 引入 `DataRepository` / `RuleRepository` 接口及实现，替代 `Config.globalDataMap` 和 `Config.globalRules` 两个全局静态字段
- 抽取 `HandlerRegistry` 将 HTTP Handler 生命周期管理从 UI 层（`component/Config`）分离
- 所有依赖通过构造器从 `HaE.java` 入口点注入，消除 `DataManager` ↔ `RegularMatcher` 的循环依赖
- `DataManager` 精简为仅负责消息持久化，匹配数据持久化移入 `DataRepositoryImpl`

## Changed files (24)

| 类型 | 文件 | 说明 |
|------|------|------|
| **新建** | `repository/DataRepository.java` | 数据仓库接口 |
| **新建** | `repository/RuleRepository.java` | 规则仓库接口 |
| **新建** | `repository/impl/DataRepositoryImpl.java` | ConcurrentHashMap + BurpSuite 持久化 |
| **新建** | `repository/impl/RuleRepositoryImpl.java` | synchronized HashMap |
| **新建** | `service/HandlerRegistry.java` | Handler 注册/注销/模式切换 |
| **修改** | `Config.java` | 删除 `globalDataMap`, `globalRules` |
| **修改** | `HaE.java` | 组装完整依赖图 |
| **修改** | `RegularMatcher.java` | 删除 `updateGlobalMatchCache()`，用 `dataRepository.mergeData()` |
| **修改** | 其余 16 个文件 | 构造器注入 Repository 依赖 |

## Test plan

- [ ] `gradle compileJava` 编译通过（已验证）
- [ ] `gradle jar` 构建 fat JAR 成功（已验证）
- [ ] BurpSuite 加载扩展无报错
- [ ] Rules 标签页正常加载规则
- [ ] 规则增删改 + 自动保存到 Rules.yml
- [ ] 浏览网页后 Databoard 能看到提取的数据
- [ ] Handler 模式切换（Active/Passive）正常
- [ ] Clear data / Clear cache 按钮正常
- [ ] 消息编辑器（Request/Response/WebSocket Editor）正常显示高亮
- [ ] 重启 BurpSuite 后数据持久化正常